### PR TITLE
redo ExtractROI

### DIFF
--- a/pydra/tasks/fsl/utils/extractroi.py
+++ b/pydra/tasks/fsl/utils/extractroi.py
@@ -32,9 +32,7 @@ input_fields = [
     ("t_min", int, {"help_string": "", "argstr": "{t_min}", "position": 8}),
     ("t_size", int, {"help_string": "", "argstr": "{t_size}", "position": 9}),
 ]
-ExtractROI_input_spec = specs.SpecInfo(
-    name="Input", fields=input_fields, bases=(specs.ShellSpec,)
-)
+ExtractROI_input_spec = specs.SpecInfo(name="Input", fields=input_fields, bases=(specs.ShellSpec,))
 
 output_fields = []
 ExtractROI_output_spec = specs.SpecInfo(

--- a/pydra/tasks/fsl/utils/extractroi.py
+++ b/pydra/tasks/fsl/utils/extractroi.py
@@ -20,7 +20,7 @@ input_fields = [
             "help_string": "output file",
             "argstr": "{roi_file}",
             "position": 1,
-            "output_file_template": "{in_file}_trim",
+            "output_file_template": "{in_file}_roi",
         },
     ),
     ("x_min", int, {"help_string": "", "argstr": "{x_min}", "position": 2}),
@@ -32,7 +32,9 @@ input_fields = [
     ("t_min", int, {"help_string": "", "argstr": "{t_min}", "position": 8}),
     ("t_size", int, {"help_string": "", "argstr": "{t_size}", "position": 9}),
 ]
-ExtractROI_input_spec = specs.SpecInfo(name="Input", fields=input_fields, bases=(specs.ShellSpec,))
+ExtractROI_input_spec = specs.SpecInfo(
+    name="Input", fields=input_fields, bases=(specs.ShellSpec,)
+)
 
 output_fields = []
 ExtractROI_output_spec = specs.SpecInfo(
@@ -48,9 +50,9 @@ class ExtractROI(ShellCommandTask):
     >>> task.inputs.in_file = "test.nii.gz"
     >>> task.inputs.t_min = 0
     >>> task.inputs.t_size = 3
-    >>> task.inputs.roi_file = "test_trim.nii.gz"
+    >>> task.inputs.roi_file = "test_roi.nii.gz"
     >>> task.cmdline
-    'fslroi test.nii.gz test_trim.nii.gz 0 3'
+    'fslroi test.nii.gz test_roi.nii.gz 0 3'
     """
 
     input_spec = ExtractROI_input_spec

--- a/pydra/tasks/fsl/utils/tests/test_run_extractroi.py
+++ b/pydra/tasks/fsl/utils/tests/test_run_extractroi.py
@@ -3,9 +3,7 @@ from pathlib import Path
 from ..extractroi import ExtractROI
 
 
-@pytest.mark.xfail(
-    "FSLDIR" not in os.environ, reason="no FSL found", raises=FileNotFoundError
-)
+@pytest.mark.xfail("FSLDIR" not in os.environ, reason="no FSL found", raises=FileNotFoundError)
 @pytest.mark.parametrize(
     "inputs, outputs",
     [
@@ -50,9 +48,7 @@ def test_ExtractROI(test_data, inputs, outputs):
             except:
                 pass
         task = ExtractROI(**inputs)
-    assert set(task.generated_output_names) == set(
-        ["return_code", "stdout", "stderr"] + outputs
-    )
+    assert set(task.generated_output_names) == set(["return_code", "stdout", "stderr"] + outputs)
     res = task()
     print("RESULT: ", res)
     for out_nm in outputs:

--- a/pydra/tasks/fsl/utils/tests/test_run_extractroi.py
+++ b/pydra/tasks/fsl/utils/tests/test_run_extractroi.py
@@ -3,10 +3,26 @@ from pathlib import Path
 from ..extractroi import ExtractROI
 
 
-@pytest.mark.xfail("FSLDIR" not in os.environ, reason="no FSL found", raises=FileNotFoundError)
+@pytest.mark.xfail(
+    "FSLDIR" not in os.environ, reason="no FSL found", raises=FileNotFoundError
+)
 @pytest.mark.parametrize(
     "inputs, outputs",
-    [({"in_file": "test.nii.gz", "t_min": 0, "t_size": 1}, ["roi_file"])],
+    [
+        ({"in_file": "test.nii.gz", "t_min": 0, "t_size": 1}, ["roi_file"]),
+        (
+            {
+                "in_file": "test.nii.gz",
+                "x_min": 0,
+                "x_size": 1,
+                "y_min": 20,
+                "y_size": 1,
+                "z_min": 10,
+                "z_size": 1,
+            },
+            ["roi_file"],
+        ),
+    ],
 )
 def test_ExtractROI(test_data, inputs, outputs):
     if inputs is None:
@@ -34,7 +50,9 @@ def test_ExtractROI(test_data, inputs, outputs):
             except:
                 pass
         task = ExtractROI(**inputs)
-    assert set(task.generated_output_names) == set(["return_code", "stdout", "stderr"] + outputs)
+    assert set(task.generated_output_names) == set(
+        ["return_code", "stdout", "stderr"] + outputs
+    )
     res = task()
     print("RESULT: ", res)
     for out_nm in outputs:

--- a/pydra/tasks/fsl/utils/tests/test_spec_extractroi.py
+++ b/pydra/tasks/fsl/utils/tests/test_spec_extractroi.py
@@ -47,6 +47,4 @@ def test_ExtractROI(test_data, inputs, outputs):
             except:
                 pass
         task = ExtractROI(**inputs)
-    assert set(task.generated_output_names) == set(
-        ["return_code", "stdout", "stderr"] + outputs
-    )
+    assert set(task.generated_output_names) == set(["return_code", "stdout", "stderr"] + outputs)

--- a/pydra/tasks/fsl/utils/tests/test_spec_extractroi.py
+++ b/pydra/tasks/fsl/utils/tests/test_spec_extractroi.py
@@ -5,7 +5,21 @@ from ..extractroi import ExtractROI
 
 @pytest.mark.parametrize(
     "inputs, outputs",
-    [({"in_file": "test.nii.gz", "t_min": 0, "t_size": 1}, ["roi_file"])],
+    [
+        ({"in_file": "test.nii.gz", "t_min": 0, "t_size": 1}, ["roi_file"]),
+        (
+            {
+                "in_file": "test.nii.gz",
+                "x_min": 0,
+                "x_size": 1,
+                "y_min": 20,
+                "y_size": 1,
+                "z_min": 10,
+                "z_size": 1,
+            },
+            ["roi_file"],
+        ),
+    ],
 )
 def test_ExtractROI(test_data, inputs, outputs):
     if inputs is None:
@@ -33,4 +47,6 @@ def test_ExtractROI(test_data, inputs, outputs):
             except:
                 pass
         task = ExtractROI(**inputs)
-    assert set(task.generated_output_names) == set(["return_code", "stdout", "stderr"] + outputs)
+    assert set(task.generated_output_names) == set(
+        ["return_code", "stdout", "stderr"] + outputs
+    )

--- a/specs/fsl_utils_param.yml
+++ b/specs/fsl_utils_param.yml
@@ -90,20 +90,28 @@ ExtractROI:
   output_requirements:
     roi_file: [in_file]
   output_templates:
-    roi_file: "{in_file}_trim"
+    roi_file: "{in_file}_roi"
   inputs_drop:
     - crop_list
   doctest:
     in_file: test.nii.gz
     t_min: 0
     t_size: 3
-    roi_file: test_trim.nii.gz
-    cmdline: fslroi test.nii.gz test_trim.nii.gz 0 3
+    roi_file: test_roi.nii.gz
+    cmdline: fslroi test.nii.gz test_roi.nii.gz 0 3
   tests_inputs:
     - in_file: test.nii.gz
       t_min: 0
       t_size: 1
+    - in_file: test.nii.gz
+      x_min: 0
+      x_size: 1
+      y_min: 20
+      y_size: 1
+      z_min: 10
+      z_size: 1
   tests_outputs:
+    - roi_file
     - roi_file
 
 FilterRegressor:


### PR DESCRIPTION
Hi @djarecka , I redid `extractroi` by changing the output basename from `_trim` to `_roi`.  (passed pytest locally)
(just a note from today's discussion) @effigies mentioned that we can set requirements for argstr that for each of x_min, x_size, y_min, y_size, z_min, z_size requires [x_min, x_size, y_min, y_size, z_min, z_size], then for t_min, t_size, requires [t_min, t_size]. We can manually do this.
our current converter has something called `input_drops` [link](https://github.com/yibeichan/pydra-fsl/blob/1e4061397e89569a75ad249a38e413ab0e977b98/specs/fsl_utils_param.yml#L94), of which the usage can be found [here](https://github.com/nipype/pydra-fsl/issues/34). So it inherits the `crop_list` from `nipype`
let me know what we want to do with `extractroi` further. 